### PR TITLE
Migrate from `rules_bzlformat`, `rules_updatesrc`, and `bazel_shlib` to `bazel-starlib`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    "@cgrindel_rules_updatesrc//updatesrc:updatesrc.bzl",
+    "@cgrindel_bazel_starlib//updatesrc:defs.bzl",
     "updatesrc_update_all",
 )
 load(
-    "@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl",
+    "@cgrindel_bazel_starlib//bzlformat:defs.bzl",
     "bzlformat_missing_pkgs",
     "bzlformat_pkg",
 )

--- a/Sources/DateUtils/BUILD.bazel
+++ b/Sources/DateUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/MathUtils/BUILD.bazel
+++ b/Sources/MathUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/NumberUtils/BUILD.bazel
+++ b/Sources/NumberUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/OptionalUtils/BUILD.bazel
+++ b/Sources/OptionalUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/StringUtils/BUILD.bazel
+++ b/Sources/StringUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/StructUtils/BUILD.bazel
+++ b/Sources/StructUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/Truth/BUILD.bazel
+++ b/Sources/Truth/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Sources/TypeUtils/BUILD.bazel
+++ b/Sources/TypeUtils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_library.bzl", "swift_library")
 
 swift_library(

--- a/Tests/DateUtilsTests/BUILD.bazel
+++ b/Tests/DateUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/MathUtilsTests/BUILD.bazel
+++ b/Tests/MathUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/NumberUtilsTests/BUILD.bazel
+++ b/Tests/NumberUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/OptionalUtilsTests/BUILD.bazel
+++ b/Tests/OptionalUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/StringUtilsTests/BUILD.bazel
+++ b/Tests/StringUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/StructUtilsTests/BUILD.bazel
+++ b/Tests/StructUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/TruthTests/BUILD.bazel
+++ b/Tests/TruthTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/Tests/TypeUtilsTests/BUILD.bazel
+++ b/Tests/TypeUtilsTests/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@cgrindel_rules_bzlformat//bzlformat:bzlformat.bzl", "bzlformat_pkg")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
 load("//build/swift:swift_test.bzl", "swift_test")
 
 swift_test(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,23 +32,17 @@ load("@cgrindel_rules_swiftformat//swiftformat:load_package.bzl", "swiftformat_l
 
 swiftformat_load_package()
 
-# MARK: - rules_bzlformat Dependencies
-
-load("@cgrindel_rules_bzlformat//bzlformat:deps.bzl", "bzlformat_rules_dependencies")
-
-bzlformat_rules_dependencies()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
+# MARK: - bazel-starlib Dependencies
 
 load("@cgrindel_bazel_starlib//:deps.bzl", "bazel_starlib_dependencies")
 
 bazel_starlib_dependencies()
 
-load("@cgrindel_rules_updatesrc//updatesrc:deps.bzl", "updatesrc_rules_dependencies")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
-updatesrc_rules_dependencies()
+bazel_skylib_workspace()
+
+# MARK: - Buildifier
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -9,7 +9,8 @@ def swift_toolbox_dependencies():
         url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
     )
 
-    http_archive(
+    maybe(
+        http_archive,
         name = "cgrindel_bazel_starlib",
         sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
         strip_prefix = "bazel-starlib-0.2.0",

--- a/deps.bzl
+++ b/deps.bzl
@@ -10,11 +10,9 @@ def swift_toolbox_dependencies():
     )
 
     maybe(
-        http_archive,
-        name = "cgrindel_rules_bzlformat",
-        sha256 = "44b09ad9c5395760065820676ba6e65efec08ae02c1ce7e2d39d42c5b1e7aec8",
-        strip_prefix = "rules_bzlformat-0.2.1",
-        urls = ["https://github.com/cgrindel/rules_bzlformat/archive/v0.2.1.tar.gz"],
+        native.local_repository,
+        name = "cgrindel_bazel_starlib",
+        path = "../bazel-starlib",
     )
 
     maybe(

--- a/deps.bzl
+++ b/deps.bzl
@@ -9,10 +9,13 @@ def swift_toolbox_dependencies():
         url = "https://github.com/bazelbuild/rules_swift/releases/download/0.24.0/rules_swift.0.24.0.tar.gz",
     )
 
-    maybe(
-        native.local_repository,
+    http_archive(
         name = "cgrindel_bazel_starlib",
-        path = "../bazel-starlib",
+        sha256 = "238c05abf31447b93bd15b616c7413c4c719ee7b5e81c1489ca20f02ce628489",
+        strip_prefix = "bazel-starlib-0.2.0",
+        urls = [
+            "http://github.com/cgrindel/bazel-starlib/archive/v0.2.0.tar.gz",
+        ],
     )
 
     maybe(


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#44.