### PR TITLE
feat: add `isIdenticalTo()` and `isNotIdenticalTo()`

### DIFF
--- a/Sources/Truth/AnyObectAssertions.swift
+++ b/Sources/Truth/AnyObectAssertions.swift
@@ -1,0 +1,18 @@
+public extension Subject where T: AnyObject {
+  /// Asserts that the actual value is nil.
+  @discardableResult func isIdenticalTo(
+    _ expected: T,
+    file: StaticString = #file, line: UInt = #line
+  ) -> Self {
+    return doAssert(
+      failWith: Failure(
+        file: file,
+        line: line,
+        Fact("expected", expected),
+        Fact("to be identical to", actual)
+      )
+    ) {
+      actual === expected
+    }
+  }
+}

--- a/Sources/Truth/AnyObectAssertions.swift
+++ b/Sources/Truth/AnyObectAssertions.swift
@@ -1,5 +1,5 @@
 public extension Subject where T: AnyObject {
-  /// Asserts that the actual value is nil.
+  /// Asserts that the actual value is identical (===) to expected.
   @discardableResult func isIdenticalTo(
     _ expected: T,
     file: StaticString = #file, line: UInt = #line
@@ -13,6 +13,22 @@ public extension Subject where T: AnyObject {
       )
     ) {
       actual === expected
+    }
+  }
+
+  /// Asserts that the actual value is not identical (!==) to expected.
+  @discardableResult func isNotIdenticalTo(
+    _ expected: T,
+    file: StaticString = #file, line: UInt = #line
+  ) -> Self {
+    return doAssert(
+      failWith: Failure(
+        file: file,
+        line: line,
+        Fact("expected not to be identical to", expected)
+      )
+    ) {
+      actual !== expected
     }
   }
 }

--- a/Sources/Truth/BUILD.bazel
+++ b/Sources/Truth/BUILD.bazel
@@ -7,6 +7,7 @@ swift_library(
     name = "Truth",
     testonly = True,  # keep
     srcs = [
+        "AnyObectAssertions.swift",
         "AssertThat.swift",
         "BidirectionalCollectionAssertions.swift",
         "BinaryIntegerAssertions.swift",

--- a/Tests/TruthTests/AnyObectAssertionsTests.swift
+++ b/Tests/TruthTests/AnyObectAssertionsTests.swift
@@ -23,4 +23,18 @@ class AnyObectAssertionsTests: XCTestCase {
       $0.that(actual).isIdenticalTo(expected)
     }
   }
+
+  func test_isNotIdenticalTo_WithDifferentObjs_Succeeds() throws {
+    let actual = Foo(name: "Jim")
+    let expected = Foo(name: "Jim")
+    assertNoFailures { $0.that(actual).isNotIdenticalTo(expected) }
+  }
+
+  func test_isNotIdenticalTo_WithIdenticalObjs_Fails() throws {
+    let actual = Foo(name: "Jim")
+    let expected = actual
+    assertFailure([Fact("expected not to be identical to", expected)]) {
+      $0.that(actual).isNotIdenticalTo(expected)
+    }
+  }
 }

--- a/Tests/TruthTests/AnyObectAssertionsTests.swift
+++ b/Tests/TruthTests/AnyObectAssertionsTests.swift
@@ -1,0 +1,26 @@
+@testable import Truth
+import XCTest
+
+class AnyObectAssertionsTests: XCTestCase {
+  class Foo {
+    var name: String
+
+    init(name: String) {
+      self.name = name
+    }
+  }
+
+  func test_isIdenticalTo_WithIdenticalObjs_Succeeds() throws {
+    let actual = Foo(name: "Jim")
+    let expected = actual
+    assertNoFailures { $0.that(actual).isIdenticalTo(expected) }
+  }
+
+  func test_isIdenticalTo_WithDifferentObjs_Fails() throws {
+    let actual = Foo(name: "Jim")
+    let expected = Foo(name: "Jim")
+    assertFailure([Fact("expected", expected), Fact("to be identical to", actual)]) {
+      $0.that(actual).isIdenticalTo(expected)
+    }
+  }
+}

--- a/Tests/TruthTests/BUILD.bazel
+++ b/Tests/TruthTests/BUILD.bazel
@@ -6,6 +6,7 @@ bzlformat_pkg(name = "bzlformat")
 swift_test(
     name = "TruthTests",
     srcs = [
+        "AnyObectAssertionsTests.swift",
         "AssertThatTests.swift",
         "AssertionConsumerError.swift",
         "BidirectionalCollectionAssertionsTests.swift",


### PR DESCRIPTION
- The `isIdenticalTo()` performs a `===` on subjects that are `AnyObject`.
- The `isNotIdenticalTo()` performs a `!==` on subjects that are `AnyObject`.

Closes #109.